### PR TITLE
Fixing random issue in unit tests

### DIFF
--- a/assistive-webdriver/src/server/nativeEvents.ts
+++ b/assistive-webdriver/src/server/nativeEvents.ts
@@ -83,6 +83,8 @@ class KeyboardInputSource extends NullInputSource {
   }
 }
 
+const STEP_DELAY = 50;
+
 class PointerInputSource extends NullInputSource {
   async execute_pointerMove(action: any) {
     const originPosition = await this.getPosition(action.origin);
@@ -114,8 +116,11 @@ class PointerInputSource extends NullInputSource {
       });
       currentTime = Date.now();
       remainingTime = endTime - currentTime;
-      if (remainingTime > 0) {
-        await wait(Math.min(remainingTime, 50));
+      if (remainingTime <= STEP_DELAY) {
+        await wait(remainingTime);
+        break;
+      } else {
+        await wait(STEP_DELAY);
         currentTime = Date.now();
         remainingTime = endTime - currentTime;
       }

--- a/assistive-webdriver/src/server/nativeEvents.ts
+++ b/assistive-webdriver/src/server/nativeEvents.ts
@@ -99,9 +99,8 @@ class PointerInputSource extends NullInputSource {
       x: Math.round(originPosition.x + action.x),
       y: Math.round(originPosition.y + action.y)
     };
-    let currentTime = Date.now();
-    const endTime = currentTime + duration;
-    let remainingTime = endTime - currentTime;
+    const endTime = Date.now() + duration;
+    let remainingTime = duration;
     while (remainingTime > 0) {
       const howCloseToEnd = remainingTime / duration;
       mousePosition.x = Math.round(
@@ -114,15 +113,13 @@ class PointerInputSource extends NullInputSource {
         ...to,
         ...mousePosition
       });
-      currentTime = Date.now();
-      remainingTime = endTime - currentTime;
+      remainingTime = endTime - Date.now();
       if (remainingTime <= STEP_DELAY) {
         await wait(remainingTime);
         break;
       } else {
         await wait(STEP_DELAY);
-        currentTime = Date.now();
-        remainingTime = endTime - currentTime;
+        remainingTime = endTime - Date.now();
       }
     }
     mousePosition.x = to.x;


### PR DESCRIPTION
The problem is coming either from `setTimeout` not always waiting enough time or `Date.now()` not returning the correct time at the time `setTimeout` calls its callback:

```js
const currentTime = Date.now();
await new Promise(resolve => setTimeout(resolve, delay));
const newCurrentTime = Date.now();
// The following expression is not always true:
// newCurrentTime >= currentTime + delay
```

The actual code is this one (cf https://github.com/divdavem/Assistive-Webdriver/blob/f4d71519f826cf1d8080771cfaa781c9b9f8ac1d/assistive-webdriver/src/server/nativeEvents.ts#L127-L135):

```js
      currentTime = Date.now();
      remainingTime = endTime - currentTime;
      info.push({ pos: 3, currentTime, endTime, remainingTime });
      if (remainingTime > 0) {
        await wait(Math.min(remainingTime, 50));
        currentTime = Date.now();
        remainingTime = endTime - currentTime;
        info.push({ pos: 4, currentTime, endTime, remainingTime });
      }
```

When it is run multiple times in the CI environment, the following log is sometimes produced (cf https://github.com/divdavem/Assistive-Webdriver/runs/1181020310):

>     console.log
>       INFO (afterAll) =  [
>         { fromX: 45, fromY: 109, toX: 83, toY: 104, duration: 10 },
>         {
>           pos: 1,
>           currentTime: 1601368143245,
>           endTime: 1601368143255,
>           remainingTime: 10
>         },
>         { pos: 2, x: 45, y: 109 },
>         {
>           pos: 3,
>           currentTime: 1601368143246,
>           endTime: 1601368143255,
>           remainingTime: 9
>         },
>         {
>           pos: 4,
>           currentTime: 1601368143254,
>           endTime: 1601368143255,
>           remainingTime: 1
>         },
>         { pos: 2, x: 79, y: 105 }
>       ]

cf issue in node.js: https://github.com/nodejs/node/issues/33382